### PR TITLE
Added custom assertions

### DIFF
--- a/include/GooseFEM/Element.hpp
+++ b/include/GooseFEM/Element.hpp
@@ -48,8 +48,8 @@ inline xt::xtensor<double,2> assembleNodeVector(
   size_t ndim  = elemvec.shape()[2];
   size_t nnode = xt::amax(conn)[0]+1;
 
-  assert(elemvec.shape()[0] == nelem);
-  assert(elemvec.shape()[1] == nne  );
+  GOOSEFEM_ASSERT(elemvec.shape()[0] == nelem);
+  GOOSEFEM_ASSERT(elemvec.shape()[1] == nne);
 
   xt::xtensor<double,2> nodevec = xt::zeros<double>({nnode, ndim});
 
@@ -84,7 +84,7 @@ inline bool isSequential(const E& dofs)
 
 inline bool isDiagonal(const xt::xtensor<double,3>& elemmat)
 {
-  assert(elemmat.shape()[1] == elemmat.shape()[2]);
+  GOOSEFEM_ASSERT(elemmat.shape()[1] == elemmat.shape()[2]);
 
   size_t nelem = elemmat.shape()[0];
   size_t N     = elemmat.shape()[1];

--- a/include/GooseFEM/ElementHex8.hpp
+++ b/include/GooseFEM/ElementHex8.hpp
@@ -160,7 +160,7 @@ inline xt::xtensor<double,1> w()
 // =================================================================================================
 
 inline Quadrature::Quadrature(const xt::xtensor<double,3>& x) :
-  Quadrature(x, Gauss::xi(), Gauss::w()) {};
+  Quadrature(x, Gauss::xi(), Gauss::w()) {}
 
 // -------------------------------------------------------------------------------------------------
 
@@ -170,15 +170,15 @@ inline Quadrature::Quadrature(
   const xt::xtensor<double,1>& w) :
   m_x(x), m_w(w), m_xi(xi)
 {
-  assert(m_x.shape()[1] == m_nne );
-  assert(m_x.shape()[2] == m_ndim);
+  GOOSEFEM_ASSERT(m_x.shape()[1] == m_nne);
+  GOOSEFEM_ASSERT(m_x.shape()[2] == m_ndim);
 
   m_nelem = m_x.shape()[0];
   m_nip   = m_w.size();
 
-  assert(m_xi.shape()[0] == m_nip );
-  assert(m_xi.shape()[1] == m_ndim);
-  assert(m_w .size()     == m_nip );
+  GOOSEFEM_ASSERT(m_xi.shape()[0] == m_nip);
+  GOOSEFEM_ASSERT(m_xi.shape()[1] == m_ndim);
+  GOOSEFEM_ASSERT(m_w.size() == m_nip);
 
   m_N    = xt::empty<double>({         m_nip, m_nne        });
   m_dNxi = xt::empty<double>({         m_nip, m_nne, m_ndim});
@@ -237,26 +237,26 @@ inline Quadrature::Quadrature(
 // -------------------------------------------------------------------------------------------------
 
 inline size_t Quadrature::nelem() const
-{ return m_nelem; };
+{ return m_nelem; }
 
 inline size_t Quadrature::nne() const
-{ return m_nne; };
+{ return m_nne; }
 
 inline size_t Quadrature::ndim() const
-{ return m_ndim; };
+{ return m_ndim; }
 
 inline size_t Quadrature::nip() const
-{ return m_nip; };
+{ return m_nip; }
 
 inline xt::xtensor<double,4> Quadrature::gradN() const
-{ return m_dNx; };
+{ return m_dNx; }
 
 // -------------------------------------------------------------------------------------------------
 
 inline void Quadrature::dV(xt::xtensor<double,2>& qscalar) const
 {
-  assert(qscalar.shape()[0] == m_nelem);
-  assert(qscalar.shape()[1] == m_nip  );
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -268,10 +268,8 @@ inline void Quadrature::dV(xt::xtensor<double,2>& qscalar) const
 
 inline void Quadrature::dV(xt::xtensor<double,4>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -285,8 +283,8 @@ inline void Quadrature::dV(xt::xtensor<double,4>& qtensor) const
 
 inline void Quadrature::dV(xt::xarray<double>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
+  GOOSEFEM_ASSERT(qtensor.shape()[0] == m_nelem);
+  GOOSEFEM_ASSERT(qtensor.shape()[1] == m_nip);
 
   xt::dynamic_shape<ptrdiff_t> strides = {
     static_cast<ptrdiff_t>(m_vol.strides()[0]),
@@ -302,10 +300,7 @@ inline void Quadrature::dV(xt::xarray<double>& qtensor) const
 
 inline void Quadrature::update_x(const xt::xtensor<double,3>& x)
 {
-  assert(x.shape()[0] == m_nelem   );
-  assert(x.shape()[1] == m_nne     );
-  assert(x.shape()[2] == m_ndim    );
-  assert(x.size()     == m_x.size());
+  GOOSEFEM_ASSERT(x.shape() == m_x.shape());
 
   xt::noalias(m_x) = x;
 
@@ -370,13 +365,10 @@ inline void Quadrature::gradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
 
   // zero-initialize
   qtensor.fill(0.0);
@@ -410,13 +402,10 @@ inline void Quadrature::gradN_vector_T(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
 
   // zero-initialize
   qtensor.fill(0.0);
@@ -450,13 +439,10 @@ inline void Quadrature::symGradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
 
   // zero-initialize
   qtensor.fill(0.0);
@@ -494,11 +480,10 @@ inline void Quadrature::int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qscalar.shape()[0] == m_nelem     );
-  assert(qscalar.shape()[1] == m_nip       );
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize: matrix of matrices
   elemmat.fill(0.0);
@@ -537,13 +522,10 @@ inline void Quadrature::int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   // zero-initialize output: matrix of vectors
   elemvec.fill(0.0);
@@ -580,16 +562,10 @@ inline void Quadrature::int_gradN_dot_tensor4_dot_gradNT_dV(
   const xt::xtensor<double,6>& qtensor,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
-  assert(qtensor.shape()[4] == m_ndim );
-  assert(qtensor.shape()[5] == m_ndim );
-
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim, m_ndim, m_ndim}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize output: matrix of vector
   elemmat.fill(0.0);
@@ -626,9 +602,7 @@ inline void Quadrature::int_gradN_dot_tensor4_dot_gradNT_dV(
 inline xt::xtensor<double,2> Quadrature::DV() const
 {
   xt::xtensor<double,2> out = xt::empty<double>({m_nelem, m_nip});
-
   this->dV(out);
-
   return out;
 }
 
@@ -642,9 +616,7 @@ inline xt::xarray<double> Quadrature::DV(size_t rank) const
     shape.push_back(static_cast<size_t>(m_ndim));
 
   xt::xarray<double> out = xt::empty<double>(shape);
-
   this->dV(out);
-
   return out;
 }
 
@@ -654,9 +626,7 @@ inline xt::xtensor<double,4> Quadrature::GradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_ndim, m_ndim});
-
   this->gradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -666,9 +636,7 @@ inline xt::xtensor<double,4> Quadrature::GradN_vector_T(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_ndim, m_ndim});
-
   this->gradN_vector_T(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -678,9 +646,7 @@ inline xt::xtensor<double,4> Quadrature::SymGradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_ndim, m_ndim});
-
   this->symGradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -690,9 +656,7 @@ inline xt::xtensor<double,3> Quadrature::Int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar) const
 {
   xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_nne*m_ndim, m_nne*m_ndim});
-
   this->int_N_scalar_NT_dV(qscalar, elemmat);
-
   return elemmat;
 }
 
@@ -702,9 +666,7 @@ inline xt::xtensor<double,3> Quadrature::Int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor) const
 {
   xt::xtensor<double,3> elemvec = xt::empty<double>({m_nelem, m_nne, m_ndim});
-
   this->int_gradN_dot_tensor2_dV(qtensor, elemvec);
-
   return elemvec;
 }
 
@@ -714,9 +676,7 @@ inline xt::xtensor<double,3> Quadrature::Int_gradN_dot_tensor4_dot_gradNT_dV(
   const xt::xtensor<double,6>& qtensor) const
  {
    xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_ndim*m_nne, m_ndim*m_nne});
-
    this->int_gradN_dot_tensor4_dot_gradNT_dV(qtensor, elemmat);
-
    return elemmat;
  }
 

--- a/include/GooseFEM/ElementQuad4.hpp
+++ b/include/GooseFEM/ElementQuad4.hpp
@@ -176,7 +176,7 @@ inline xt::xtensor<double,1> w()
 // =================================================================================================
 
 inline Quadrature::Quadrature(const xt::xtensor<double,3>& x) :
-  Quadrature(x, Gauss::xi(), Gauss::w()) {};
+  Quadrature(x, Gauss::xi(), Gauss::w()) {}
 
 // -------------------------------------------------------------------------------------------------
 
@@ -186,15 +186,15 @@ inline Quadrature::Quadrature(
   const xt::xtensor<double,1>& w) :
   m_x(x), m_w(w), m_xi(xi)
 {
-  assert(m_x.shape()[1] == m_nne );
-  assert(m_x.shape()[2] == m_ndim);
+  GOOSEFEM_ASSERT(m_x.shape()[1] == m_nne);
+  GOOSEFEM_ASSERT(m_x.shape()[2] == m_ndim);
 
   m_nelem = m_x.shape()[0];
   m_nip   = m_w.size();
 
-  assert(m_xi.shape()[0] == m_nip );
-  assert(m_xi.shape()[1] == m_ndim);
-  assert(m_w .size()     == m_nip );
+  GOOSEFEM_ASSERT(m_xi.shape()[0] == m_nip);
+  GOOSEFEM_ASSERT(m_xi.shape()[1] == m_ndim);
+  GOOSEFEM_ASSERT(m_w.size() == m_nip);
 
   m_N    = xt::empty<double>({         m_nip, m_nne        });
   m_dNxi = xt::empty<double>({         m_nip, m_nne, m_ndim});
@@ -232,26 +232,26 @@ inline Quadrature::Quadrature(
 // -------------------------------------------------------------------------------------------------
 
 inline size_t Quadrature::nelem() const
-{ return m_nelem; };
+{ return m_nelem; }
 
 inline size_t Quadrature::nne() const
-{ return m_nne; };
+{ return m_nne; }
 
 inline size_t Quadrature::ndim() const
-{ return m_ndim; };
+{ return m_ndim; }
 
 inline size_t Quadrature::nip() const
-{ return m_nip; };
+{ return m_nip; }
 
 inline xt::xtensor<double,4> Quadrature::gradN() const
-{ return m_dNx; };
+{ return m_dNx; }
 
 // -------------------------------------------------------------------------------------------------
 
 inline void Quadrature::dV(xt::xtensor<double,2>& qscalar) const
 {
-  assert(qscalar.shape()[0] == m_nelem);
-  assert(qscalar.shape()[1] == m_nip  );
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -263,10 +263,8 @@ inline void Quadrature::dV(xt::xtensor<double,2>& qscalar) const
 
 inline void Quadrature::dV(xt::xtensor<double,4>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -280,8 +278,8 @@ inline void Quadrature::dV(xt::xtensor<double,4>& qtensor) const
 
 inline void Quadrature::dV(xt::xarray<double>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
+  GOOSEFEM_ASSERT(qtensor.shape()[0] == m_nelem);
+  GOOSEFEM_ASSERT(qtensor.shape()[1] == m_nip);
 
   xt::dynamic_shape<ptrdiff_t> strides = {
     static_cast<ptrdiff_t>(m_vol.strides()[0]),
@@ -297,10 +295,7 @@ inline void Quadrature::dV(xt::xarray<double>& qtensor) const
 
 inline void Quadrature::update_x(const xt::xtensor<double,3>& x)
 {
-  assert(x.shape()[0] == m_nelem   );
-  assert(x.shape()[1] == m_nne     );
-  assert(x.shape()[2] == m_ndim    );
-  assert(x.size()     == m_x.size());
+  GOOSEFEM_ASSERT(x.shape() == m_x.shape());
 
   xt::noalias(m_x) = x;
 
@@ -362,13 +357,11 @@ inline void Quadrature::gradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
+
 
   // loop over all elements (in parallel)
   #pragma omp parallel for
@@ -400,13 +393,11 @@ inline void Quadrature::gradN_vector_T(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
+
 
   // loop over all elements (in parallel)
   #pragma omp parallel for
@@ -438,13 +429,11 @@ inline void Quadrature::symGradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
+
 
   // loop over all elements (in parallel)
   #pragma omp parallel for
@@ -478,11 +467,10 @@ inline void Quadrature::int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qscalar.shape()[0] == m_nelem     );
-  assert(qscalar.shape()[1] == m_nip       );
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize: matrix of matrices
   elemmat.fill(0.0);
@@ -520,13 +508,10 @@ inline void Quadrature::int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim}));
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   // zero-initialize output: matrix of vectors
   elemvec.fill(0.0);
@@ -562,16 +547,10 @@ inline void Quadrature::int_gradN_dot_tensor4_dot_gradNT_dV(
   const xt::xtensor<double,6>& qtensor,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_ndim );
-  assert(qtensor.shape()[3] == m_ndim );
-  assert(qtensor.shape()[4] == m_ndim );
-  assert(qtensor.shape()[5] == m_ndim );
-
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_ndim, m_ndim, m_ndim, m_ndim}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize output: matrix of vector
   elemmat.fill(0.0);
@@ -608,9 +587,7 @@ inline void Quadrature::int_gradN_dot_tensor4_dot_gradNT_dV(
 inline xt::xtensor<double,2> Quadrature::DV() const
 {
   xt::xtensor<double,2> out = xt::empty<double>({m_nelem, m_nip});
-
   this->dV(out);
-
   return out;
 }
 
@@ -624,9 +601,7 @@ inline xt::xarray<double> Quadrature::DV(size_t rank) const
     shape.push_back(static_cast<size_t>(m_ndim));
 
   xt::xarray<double> out = xt::empty<double>(shape);
-
   this->dV(out);
-
   return out;
 }
 
@@ -636,9 +611,7 @@ inline xt::xtensor<double,4> Quadrature::GradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_ndim, m_ndim});
-
   this->gradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -648,9 +621,7 @@ inline xt::xtensor<double,4> Quadrature::GradN_vector_T(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_ndim, m_ndim});
-
   this->gradN_vector_T(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -660,9 +631,7 @@ inline xt::xtensor<double,4> Quadrature::SymGradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_ndim, m_ndim});
-
   this->symGradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -672,9 +641,7 @@ inline xt::xtensor<double,3> Quadrature::Int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar) const
 {
   xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_nne*m_ndim, m_nne*m_ndim});
-
   this->int_N_scalar_NT_dV(qscalar, elemmat);
-
   return elemmat;
 }
 
@@ -684,9 +651,7 @@ inline xt::xtensor<double,3> Quadrature::Int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor) const
 {
   xt::xtensor<double,3> elemvec = xt::empty<double>({m_nelem, m_nne, m_ndim});
-
   this->int_gradN_dot_tensor2_dV(qtensor, elemvec);
-
   return elemvec;
 }
 
@@ -696,9 +661,7 @@ inline xt::xtensor<double,3> Quadrature::Int_gradN_dot_tensor4_dot_gradNT_dV(
   const xt::xtensor<double,6>& qtensor) const
  {
    xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_ndim*m_nne, m_ndim*m_nne});
-
    this->int_gradN_dot_tensor4_dot_gradNT_dV(qtensor, elemmat);
-
    return elemmat;
  }
 

--- a/include/GooseFEM/ElementQuad4Axisymmetric.hpp
+++ b/include/GooseFEM/ElementQuad4Axisymmetric.hpp
@@ -30,15 +30,15 @@ inline QuadratureAxisymmetric::QuadratureAxisymmetric(
   const xt::xtensor<double,1>& w) :
   m_x(x), m_w(w), m_xi(xi)
 {
-  assert(m_x.shape()[1] == m_nne );
-  assert(m_x.shape()[2] == m_ndim);
+  GOOSEFEM_ASSERT(m_x.shape()[1] == m_nne);
+  GOOSEFEM_ASSERT(m_x.shape()[2] == m_ndim);
 
   m_nelem = m_x.shape()[0];
   m_nip   = m_w.size();
 
-  assert(m_xi.shape()[0] == m_nip );
-  assert(m_xi.shape()[1] == m_ndim);
-  assert(m_w .size()     == m_nip );
+  GOOSEFEM_ASSERT(m_xi.shape()[0] == m_nip);
+  GOOSEFEM_ASSERT(m_xi.shape()[1] == m_ndim);
+  GOOSEFEM_ASSERT(m_w.size() == m_nip);
 
   m_N    = xt::empty<double>({         m_nip, m_nne                        });
   m_dNxi = xt::empty<double>({         m_nip, m_nne, m_ndim                });
@@ -76,23 +76,23 @@ inline QuadratureAxisymmetric::QuadratureAxisymmetric(
 // -------------------------------------------------------------------------------------------------
 
 inline size_t QuadratureAxisymmetric::nelem() const
-{ return m_nelem; };
+{ return m_nelem; }
 
 inline size_t QuadratureAxisymmetric::nne() const
-{ return m_nne; };
+{ return m_nne; }
 
 inline size_t QuadratureAxisymmetric::ndim() const
-{ return m_ndim; };
+{ return m_ndim; }
 
 inline size_t QuadratureAxisymmetric::nip() const
-{ return m_nip; };
+{ return m_nip; }
 
 // -------------------------------------------------------------------------------------------------
 
 inline void QuadratureAxisymmetric::dV(xt::xtensor<double,2>& qscalar) const
 {
-  assert(qscalar.shape()[0] == m_nelem);
-  assert(qscalar.shape()[1] == m_nip  );
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -104,10 +104,8 @@ inline void QuadratureAxisymmetric::dV(xt::xtensor<double,2>& qscalar) const
 
 inline void QuadratureAxisymmetric::dV(xt::xtensor<double,4>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -121,8 +119,8 @@ inline void QuadratureAxisymmetric::dV(xt::xtensor<double,4>& qtensor) const
 
 inline void QuadratureAxisymmetric::dV(xt::xarray<double>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
+  GOOSEFEM_ASSERT(qtensor.shape()[0] == m_nelem);
+  GOOSEFEM_ASSERT(qtensor.shape()[1] == m_nip);
 
   xt::dynamic_shape<ptrdiff_t> strides = {
     static_cast<ptrdiff_t>(m_vol.strides()[0]),
@@ -138,10 +136,7 @@ inline void QuadratureAxisymmetric::dV(xt::xarray<double>& qtensor) const
 
 inline void QuadratureAxisymmetric::update_x(const xt::xtensor<double,3>& x)
 {
-  assert(x.shape()[0] == m_nelem   );
-  assert(x.shape()[1] == m_nne     );
-  assert(x.shape()[2] == m_ndim    );
-  assert(x.size()     == m_x.size());
+  GOOSEFEM_ASSERT(x.shape() == m_x.shape());
 
   xt::noalias(m_x) = x;
 
@@ -213,13 +208,10 @@ inline void QuadratureAxisymmetric::gradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   // zero-initialize (zero components not written below)
   qtensor.fill(0.0);
@@ -256,13 +248,10 @@ inline void QuadratureAxisymmetric::gradN_vector_T(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   // zero-initialize (zero components not written below)
   qtensor.fill(0.0);
@@ -299,13 +288,10 @@ inline void QuadratureAxisymmetric::symGradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   // zero-initialize (zero components not written below)
   qtensor.fill(0.0);
@@ -344,11 +330,10 @@ inline void QuadratureAxisymmetric::int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qscalar.shape()[0] == m_nelem     );
-  assert(qscalar.shape()[1] == m_nip       );
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize: matrix of matrices
   elemmat.fill(0.0);
@@ -386,13 +371,10 @@ inline void QuadratureAxisymmetric::int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   // zero-initialize output: matrix of vectors
   elemvec.fill(0.0);
@@ -430,16 +412,10 @@ inline void QuadratureAxisymmetric::int_gradN_dot_tensor4_dot_gradNT_dV(
   const xt::xtensor<double,6>& qtensor,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
-  assert(qtensor.shape()[4] == m_tdim );
-  assert(qtensor.shape()[5] == m_tdim );
-
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim, m_tdim, m_tdim}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize output: matrix of vector
   elemmat.fill(0.0);
@@ -506,9 +482,7 @@ inline void QuadratureAxisymmetric::int_gradN_dot_tensor4_dot_gradNT_dV(
 inline xt::xtensor<double,2> QuadratureAxisymmetric::DV() const
 {
   xt::xtensor<double,2> out = xt::empty<double>({m_nelem, m_nip});
-
   this->dV(out);
-
   return out;
 }
 
@@ -522,9 +496,7 @@ inline xt::xarray<double> QuadratureAxisymmetric::DV(size_t rank) const
     shape.push_back(static_cast<size_t>(m_tdim));
 
   xt::xarray<double> out = xt::empty<double>(shape);
-
   this->dV(out);
-
   return out;
 }
 
@@ -534,9 +506,7 @@ inline xt::xtensor<double,4> QuadratureAxisymmetric::GradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_tdim, m_tdim});
-
   this->gradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -546,9 +516,7 @@ inline xt::xtensor<double,4> QuadratureAxisymmetric::GradN_vector_T(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_tdim, m_tdim});
-
   this->gradN_vector_T(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -558,9 +526,7 @@ inline xt::xtensor<double,4> QuadratureAxisymmetric::SymGradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_tdim, m_tdim});
-
   this->symGradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -570,9 +536,7 @@ inline xt::xtensor<double,3> QuadratureAxisymmetric::Int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar) const
 {
   xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_nne*m_ndim, m_nne*m_ndim});
-
   this->int_N_scalar_NT_dV(qscalar, elemmat);
-
   return elemmat;
 }
 
@@ -582,9 +546,7 @@ inline xt::xtensor<double,3> QuadratureAxisymmetric::Int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor) const
 {
   xt::xtensor<double,3> elemvec = xt::empty<double>({m_nelem, m_nne, m_ndim});
-
   this->int_gradN_dot_tensor2_dV(qtensor, elemvec);
-
   return elemvec;
 }
 
@@ -594,9 +556,7 @@ inline xt::xtensor<double,3> QuadratureAxisymmetric::Int_gradN_dot_tensor4_dot_g
   const xt::xtensor<double,6>& qtensor) const
  {
    xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_ndim*m_nne, m_ndim*m_nne});
-
    this->int_gradN_dot_tensor4_dot_gradNT_dV(qtensor, elemmat);
-
    return elemmat;
  }
 

--- a/include/GooseFEM/ElementQuad4Planar.hpp
+++ b/include/GooseFEM/ElementQuad4Planar.hpp
@@ -31,15 +31,15 @@ inline QuadraturePlanar::QuadraturePlanar(
   double thick) :
   m_x(x), m_w(w), m_xi(xi), m_thick(thick)
 {
-  assert(m_x.shape()[1] == m_nne );
-  assert(m_x.shape()[2] == m_ndim);
+  GOOSEFEM_ASSERT(m_x.shape()[1] == m_nne);
+  GOOSEFEM_ASSERT(m_x.shape()[2] == m_ndim);
 
   m_nelem = m_x.shape()[0];
   m_nip   = m_w.size();
 
-  assert(m_xi.shape()[0] == m_nip );
-  assert(m_xi.shape()[1] == m_ndim);
-  assert(m_w .size()     == m_nip );
+  GOOSEFEM_ASSERT(m_xi.shape()[0] == m_nip);
+  GOOSEFEM_ASSERT(m_xi.shape()[1] == m_ndim);
+  GOOSEFEM_ASSERT(m_w.size() == m_nip);
 
   m_N    = xt::empty<double>({         m_nip, m_nne        });
   m_dNxi = xt::empty<double>({         m_nip, m_nne, m_ndim});
@@ -77,26 +77,26 @@ inline QuadraturePlanar::QuadraturePlanar(
 // -------------------------------------------------------------------------------------------------
 
 inline size_t QuadraturePlanar::nelem() const
-{ return m_nelem; };
+{ return m_nelem; }
 
 inline size_t QuadraturePlanar::nne() const
-{ return m_nne; };
+{ return m_nne; }
 
 inline size_t QuadraturePlanar::ndim() const
-{ return m_ndim; };
+{ return m_ndim; }
 
 inline size_t QuadraturePlanar::nip() const
-{ return m_nip; };
+{ return m_nip; }
 
 inline xt::xtensor<double,4> QuadraturePlanar::gradN() const
-{ return m_dNx; };
+{ return m_dNx; }
 
 // -------------------------------------------------------------------------------------------------
 
 inline void QuadraturePlanar::dV(xt::xtensor<double,2>& qscalar) const
 {
-  assert(qscalar.shape()[0] == m_nelem);
-  assert(qscalar.shape()[1] == m_nip  );
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -108,10 +108,8 @@ inline void QuadraturePlanar::dV(xt::xtensor<double,2>& qscalar) const
 
 inline void QuadraturePlanar::dV(xt::xtensor<double,4>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -125,8 +123,8 @@ inline void QuadraturePlanar::dV(xt::xtensor<double,4>& qtensor) const
 
 inline void QuadraturePlanar::dV(xt::xarray<double>& qtensor) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
+  GOOSEFEM_ASSERT(qtensor.shape()[0] == m_nelem);
+  GOOSEFEM_ASSERT(qtensor.shape()[1] == m_nip);
 
   xt::dynamic_shape<ptrdiff_t> strides = {
     static_cast<ptrdiff_t>(m_vol.strides()[0]),
@@ -142,10 +140,7 @@ inline void QuadraturePlanar::dV(xt::xarray<double>& qtensor) const
 
 inline void QuadraturePlanar::update_x(const xt::xtensor<double,3>& x)
 {
-  assert(x.shape()[0] == m_nelem   );
-  assert(x.shape()[1] == m_nne     );
-  assert(x.shape()[2] == m_ndim    );
-  assert(x.size()     == m_x.size());
+  GOOSEFEM_ASSERT(x.shape() == m_x.shape());
 
   xt::noalias(m_x) = x;
 
@@ -207,13 +202,10 @@ inline void QuadraturePlanar::gradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   // zero-initialize (zero z-components not written below)
   qtensor.fill(0.0);
@@ -248,13 +240,10 @@ inline void QuadraturePlanar::gradN_vector_T(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   // zero-initialize (zero z-components not written below)
   qtensor.fill(0.0);
@@ -289,13 +278,10 @@ inline void QuadraturePlanar::symGradN_vector(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,4>& qtensor) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nne  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
 
   // zero-initialize (zero z-components not written below)
   qtensor.fill(0.0);
@@ -332,11 +318,10 @@ inline void QuadraturePlanar::int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qscalar.shape()[0] == m_nelem     );
-  assert(qscalar.shape()[1] == m_nip       );
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qscalar.shape() ==\
+    std::decay_t<decltype(qscalar)>::shape_type({m_nelem, m_nip}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize: matrix of matrices
   elemmat.fill(0.0);
@@ -374,13 +359,10 @@ inline void QuadraturePlanar::int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim}));
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   // zero-initialize output: matrix of vectors
   elemvec.fill(0.0);
@@ -416,16 +398,10 @@ inline void QuadraturePlanar::int_gradN_dot_tensor4_dot_gradNT_dV(
   const xt::xtensor<double,6>& qtensor,
         xt::xtensor<double,3>& elemmat) const
 {
-  assert(qtensor.shape()[0] == m_nelem);
-  assert(qtensor.shape()[1] == m_nip  );
-  assert(qtensor.shape()[2] == m_tdim );
-  assert(qtensor.shape()[3] == m_tdim );
-  assert(qtensor.shape()[4] == m_tdim );
-  assert(qtensor.shape()[5] == m_tdim );
-
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(qtensor.shape() ==\
+    std::decay_t<decltype(qtensor)>::shape_type({m_nelem, m_nip, m_tdim, m_tdim, m_tdim, m_tdim}));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   // zero-initialize output: matrix of vector
   elemmat.fill(0.0);
@@ -462,9 +438,7 @@ inline void QuadraturePlanar::int_gradN_dot_tensor4_dot_gradNT_dV(
 inline xt::xtensor<double,2> QuadraturePlanar::DV() const
 {
   xt::xtensor<double,2> out = xt::empty<double>({m_nelem, m_nip});
-
   this->dV(out);
-
   return out;
 }
 
@@ -478,9 +452,7 @@ inline xt::xarray<double> QuadraturePlanar::DV(size_t rank) const
     shape.push_back(static_cast<size_t>(m_tdim));
 
   xt::xarray<double> out = xt::empty<double>(shape);
-
   this->dV(out);
-
   return out;
 }
 
@@ -490,9 +462,7 @@ inline xt::xtensor<double,4> QuadraturePlanar::GradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_tdim, m_tdim});
-
   this->gradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -502,9 +472,7 @@ inline xt::xtensor<double,4> QuadraturePlanar::GradN_vector_T(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_tdim, m_tdim});
-
   this->gradN_vector_T(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -514,9 +482,7 @@ inline xt::xtensor<double,4> QuadraturePlanar::SymGradN_vector(
   const xt::xtensor<double,3>& elemvec) const
 {
   xt::xtensor<double,4> qtensor = xt::empty<double>({m_nelem, m_nip, m_tdim, m_tdim});
-
   this->symGradN_vector(elemvec, qtensor);
-
   return qtensor;
 }
 
@@ -526,9 +492,7 @@ inline xt::xtensor<double,3> QuadraturePlanar::Int_N_scalar_NT_dV(
   const xt::xtensor<double,2>& qscalar) const
 {
   xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_nne*m_ndim, m_nne*m_ndim});
-
   this->int_N_scalar_NT_dV(qscalar, elemmat);
-
   return elemmat;
 }
 
@@ -538,9 +502,7 @@ inline xt::xtensor<double,3> QuadraturePlanar::Int_gradN_dot_tensor2_dV(
   const xt::xtensor<double,4>& qtensor) const
 {
   xt::xtensor<double,3> elemvec = xt::empty<double>({m_nelem, m_nne, m_ndim});
-
   this->int_gradN_dot_tensor2_dV(qtensor, elemvec);
-
   return elemvec;
 }
 
@@ -550,9 +512,7 @@ inline xt::xtensor<double,3> QuadraturePlanar::Int_gradN_dot_tensor4_dot_gradNT_
   const xt::xtensor<double,6>& qtensor) const
  {
    xt::xtensor<double,3> elemmat = xt::empty<double>({m_nelem, m_ndim*m_nne, m_ndim*m_nne});
-
    this->int_gradN_dot_tensor4_dot_gradNT_dV(qtensor, elemmat);
-
    return elemmat;
  }
 

--- a/include/GooseFEM/MatrixDiagonal.hpp
+++ b/include/GooseFEM/MatrixDiagonal.hpp
@@ -33,8 +33,8 @@ inline MatrixDiagonal::MatrixDiagonal(
 
   m_inv   = xt::empty<double>({m_ndof});
 
-  assert(xt::amax(m_conn)[0] + 1 == m_nnode);
-  assert(m_ndof <= m_nnode * m_ndim);
+  GOOSEFEM_ASSERT(xt::amax(m_conn)[0] + 1 == m_nnode);
+  GOOSEFEM_ASSERT(m_ndof <= m_nnode * m_ndim);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -74,10 +74,8 @@ inline void MatrixDiagonal::factorize()
 
 inline void MatrixDiagonal::set(const xt::xtensor<double,1> &A)
 {
-  assert(A.shape()[0] == m_ndof);
-
+  GOOSEFEM_ASSERT(A.size() == m_ndof);
   std::copy(A.begin(), A.end(), m_A.begin());
-
   m_factor = true;
 }
 
@@ -85,10 +83,9 @@ inline void MatrixDiagonal::set(const xt::xtensor<double,1> &A)
 
 inline void MatrixDiagonal::assemble(const xt::xtensor<double,3> &elemmat)
 {
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
-  assert(Element::isDiagonal(elemmat));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
+  GOOSEFEM_ASSERT(Element::isDiagonal(elemmat));
 
   m_A.fill(0.0);
 
@@ -106,10 +103,10 @@ inline void MatrixDiagonal::dot(
   const xt::xtensor<double,2> &x,
         xt::xtensor<double,2> &b) const
 {
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -123,8 +120,8 @@ inline void MatrixDiagonal::dot(
   const xt::xtensor<double,1> &x,
         xt::xtensor<double,1> &b) const
 {
-  assert(x.size() == m_ndof);
-  assert(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
 
   xt::noalias(b) = m_A * x;
 }
@@ -135,10 +132,10 @@ inline void MatrixDiagonal::solve(
   const xt::xtensor<double,2> &b,
         xt::xtensor<double,2> &x)
 {
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
 
   this->factorize();
 
@@ -154,8 +151,8 @@ inline void MatrixDiagonal::solve(
   const xt::xtensor<double,1> &b,
         xt::xtensor<double,1> &x)
 {
-  assert(b.size() == m_ndof);
-  assert(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
 
   this->factorize();
 
@@ -174,9 +171,7 @@ inline xt::xtensor<double,1> MatrixDiagonal::AsDiagonal() const
 inline xt::xtensor<double,2> MatrixDiagonal::Dot(const xt::xtensor<double,2> &x) const
 {
   xt::xtensor<double,2> b = xt::empty<double>({m_nnode, m_ndim});
-
   this->dot(x, b);
-
   return b;
 }
 
@@ -185,9 +180,7 @@ inline xt::xtensor<double,2> MatrixDiagonal::Dot(const xt::xtensor<double,2> &x)
 inline xt::xtensor<double,1> MatrixDiagonal::Dot(const xt::xtensor<double,1> &x) const
 {
   xt::xtensor<double,1> b = xt::empty<double>({m_ndof});
-
   this->dot(x, b);
-
   return b;
 }
 
@@ -196,9 +189,7 @@ inline xt::xtensor<double,1> MatrixDiagonal::Dot(const xt::xtensor<double,1> &x)
 inline xt::xtensor<double,2> MatrixDiagonal::Solve(const xt::xtensor<double,2> &b)
 {
   xt::xtensor<double,2> x = xt::empty<double>({m_nnode, m_ndim});
-
   this->solve(b, x);
-
   return x;
 }
 
@@ -207,9 +198,7 @@ inline xt::xtensor<double,2> MatrixDiagonal::Solve(const xt::xtensor<double,2> &
 inline xt::xtensor<double,1> MatrixDiagonal::Solve(const xt::xtensor<double,1> &b)
 {
   xt::xtensor<double,1> x = xt::empty<double>({m_ndof});
-
   this->solve(b, x);
-
   return x;
 }
 

--- a/include/GooseFEM/MatrixDiagonalPartitioned.hpp
+++ b/include/GooseFEM/MatrixDiagonalPartitioned.hpp
@@ -42,9 +42,9 @@ inline MatrixDiagonalPartitioned::MatrixDiagonalPartitioned(
 
   m_inv_uu = xt::empty<double>({m_nnu});
 
-  assert(xt::amax(m_conn)[0] + 1 == m_nnode);
-  assert(xt::amax(m_iip)[0] <= xt::amax(m_dofs)[0]);
-  assert(m_ndof <= m_nnode * m_ndim);
+  GOOSEFEM_ASSERT(xt::amax(m_conn)[0] + 1 == m_nnode);
+  GOOSEFEM_ASSERT(xt::amax(m_iip)[0] <= xt::amax(m_dofs)[0]);
+  GOOSEFEM_ASSERT(m_ndof <= m_nnode * m_ndim);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -96,10 +96,9 @@ inline void MatrixDiagonalPartitioned::factorize()
 
 inline void MatrixDiagonalPartitioned::assemble(const xt::xtensor<double,3> &elemmat)
 {
-  assert(elemmat.shape()[0] == m_nelem);
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
-  assert(Element::isDiagonal(elemmat));
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
+  GOOSEFEM_ASSERT(Element::isDiagonal(elemmat));
 
   m_Auu.fill(0.0);
   m_App.fill(0.0);
@@ -127,10 +126,10 @@ inline void MatrixDiagonalPartitioned::dot(
   const xt::xtensor<double,2> &x,
         xt::xtensor<double,2> &b) const
 {
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m) {
@@ -150,8 +149,8 @@ inline void MatrixDiagonalPartitioned::dot(
   const xt::xtensor<double,1> &x,
         xt::xtensor<double,1> &b) const
 {
-  assert(x.size() == m_ndof);
-  assert(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnu ; ++d)
@@ -171,9 +170,9 @@ inline void MatrixDiagonalPartitioned::dot_u(
 {
   UNUSED(x_p);
 
-  assert(x_u.size() == m_nnu);
-  assert(x_p.size() == m_nnp);
-  assert(b_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(x_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(x_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(b_u.size() == m_nnu);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnu ; ++d)
@@ -189,9 +188,9 @@ inline void MatrixDiagonalPartitioned::dot_p(
 {
   UNUSED(x_u);
 
-  assert(x_u.size() == m_nnu);
-  assert(x_p.size() == m_nnp);
-  assert(b_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(x_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(x_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(b_p.size() == m_nnp);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnp ; ++d)
@@ -204,10 +203,10 @@ inline void MatrixDiagonalPartitioned::solve(
   const xt::xtensor<double,2> &b,
         xt::xtensor<double,2> &x)
 {
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
 
   this->factorize();
 
@@ -224,8 +223,8 @@ inline void MatrixDiagonalPartitioned::solve(
   const xt::xtensor<double,1> &b,
         xt::xtensor<double,1> &x)
 {
-  assert(b.size() == m_ndof);
-  assert(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
 
   this->factorize();
 
@@ -243,9 +242,9 @@ inline void MatrixDiagonalPartitioned::solve_u(
 {
   UNUSED(x_p);
 
-  assert(b_u.shape()[0] == m_nnu);
-  assert(x_p.shape()[0] == m_nnp);
-  assert(x_u.shape()[0] == m_nnu);
+  GOOSEFEM_ASSERT(b_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(x_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(x_u.size() == m_nnu);
 
   this->factorize();
 
@@ -260,10 +259,10 @@ inline void MatrixDiagonalPartitioned::reaction(
   const xt::xtensor<double,2> &x,
         xt::xtensor<double,2> &b) const
 {
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -278,8 +277,8 @@ inline void MatrixDiagonalPartitioned::reaction(
   const xt::xtensor<double,1> &x,
         xt::xtensor<double,1> &b) const
 {
-  assert(x.size() == m_ndof);
-  assert(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnp ; ++d)
@@ -295,9 +294,9 @@ inline void MatrixDiagonalPartitioned::reaction_p(
 {
   UNUSED(x_u);
 
-  assert(x_u.shape()[0] == m_nnu);
-  assert(x_p.shape()[0] == m_nnp);
-  assert(b_p.shape()[0] == m_nnp);
+  GOOSEFEM_ASSERT(x_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(x_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(b_p.size() == m_nnp);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnp ; ++d)
@@ -327,9 +326,7 @@ inline xt::xtensor<double,2> MatrixDiagonalPartitioned::Dot(
   const xt::xtensor<double,2> &x) const
 {
   xt::xtensor<double,2> b = xt::empty<double>({m_nnode, m_ndim});
-
   this->dot(x, b);
-
   return b;
 }
 
@@ -339,9 +336,7 @@ inline xt::xtensor<double,1> MatrixDiagonalPartitioned::Dot(
   const xt::xtensor<double,1> &x) const
 {
   xt::xtensor<double,1> b = xt::empty<double>({m_ndof});
-
   this->dot(x, b);
-
   return b;
 }
 
@@ -352,9 +347,7 @@ inline xt::xtensor<double,1> MatrixDiagonalPartitioned::Dot_u(
   const xt::xtensor<double,1> &x_p) const
 {
   xt::xtensor<double,1> b_u = xt::empty<double>({m_nnu});
-
   this->dot_u(x_u, x_p, b_u);
-
   return b_u;
 }
 
@@ -365,9 +358,7 @@ inline xt::xtensor<double,1> MatrixDiagonalPartitioned::Dot_p(
   const xt::xtensor<double,1> &x_p) const
 {
   xt::xtensor<double,1> b_p = xt::empty<double>({m_nnp});
-
   this->dot_p(x_u, x_p, b_p);
-
   return b_p;
 }
 
@@ -378,9 +369,7 @@ inline xt::xtensor<double,2> MatrixDiagonalPartitioned::Solve(
   const xt::xtensor<double,2> &x)
 {
   xt::xtensor<double,2> out = x;
-
   this->solve(b, out);
-
   return out;
 }
 
@@ -391,9 +380,7 @@ inline xt::xtensor<double,1> MatrixDiagonalPartitioned::Solve(
   const xt::xtensor<double,1> &x)
 {
   xt::xtensor<double,1> out = x;
-
   this->solve(b, out);
-
   return out;
 }
 
@@ -404,9 +391,7 @@ inline xt::xtensor<double,1> MatrixDiagonalPartitioned::Solve_u(
   const xt::xtensor<double,1> &x_p)
 {
   xt::xtensor<double,1> x_u = xt::empty<double>({m_nnu});
-
   this->solve_u(b_u, x_p, x_u);
-
   return x_u;
 }
 
@@ -417,9 +402,7 @@ inline xt::xtensor<double,2> MatrixDiagonalPartitioned::Reaction(
   const xt::xtensor<double,2> &b) const
 {
   xt::xtensor<double,2> out = b;
-
   this->reaction(x, out);
-
   return out;
 }
 
@@ -430,9 +413,7 @@ inline xt::xtensor<double,1> MatrixDiagonalPartitioned::Reaction(
   const xt::xtensor<double,1> &b) const
 {
   xt::xtensor<double,1> out = b;
-
   this->reaction(x, out);
-
   return out;
 }
 
@@ -443,9 +424,7 @@ inline xt::xtensor<double,1> MatrixDiagonalPartitioned::Reaction_p(
   const xt::xtensor<double,1> &x_p) const
 {
   xt::xtensor<double,1> b_p = xt::empty<double>({m_nnp});
-
   this->reaction_p(x_u, x_p, b_p);
-
   return b_p;
 }
 

--- a/include/GooseFEM/MatrixPartitioned.hpp
+++ b/include/GooseFEM/MatrixPartitioned.hpp
@@ -47,9 +47,9 @@ inline MatrixPartitioned::MatrixPartitioned(
   m_Apu.resize(m_nnp,m_nnu);
   m_App.resize(m_nnp,m_nnp);
 
-  assert(xt::amax(m_conn)[0] + 1 == m_nnode);
-  assert(xt::amax(m_iip)[0] <= xt::amax(m_dofs)[0]);
-  assert(m_ndof <= m_nnode * m_ndim);
+  GOOSEFEM_ASSERT(xt::amax(m_conn)[0] + 1 == m_nnode);
+  GOOSEFEM_ASSERT(xt::amax(m_iip)[0] <= xt::amax(m_dofs)[0]);
+  GOOSEFEM_ASSERT(m_ndof <= m_nnode * m_ndim);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -100,9 +100,8 @@ inline void MatrixPartitioned::factorize()
 
 inline void MatrixPartitioned::assemble(const xt::xtensor<double,3> &elemmat)
 {
-  assert(elemmat.shape()[0] == m_nelem);
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   m_Tuu.clear();
   m_Tup.clear();
@@ -148,10 +147,10 @@ inline void MatrixPartitioned::solve(
   const xt::xtensor<double,2> &b,
         xt::xtensor<double,2> &x)
 {
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
 
   this->factorize();
 
@@ -173,8 +172,8 @@ inline void MatrixPartitioned::solve(
   const xt::xtensor<double,1> &b,
         xt::xtensor<double,1> &x)
 {
-  assert(b.size() == m_ndof);
-  assert(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
 
   this->factorize();
 
@@ -195,9 +194,9 @@ inline void MatrixPartitioned::solve_u(
   const xt::xtensor<double,1> &x_p,
         xt::xtensor<double,1> &x_u)
 {
-  assert(b_u.shape()[0] == m_nnu);
-  assert(x_p.shape()[0] == m_nnp);
-  assert(x_u.shape()[0] == m_nnu);
+  GOOSEFEM_ASSERT(b_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(x_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(x_u.size() == m_nnu);
 
   this->factorize();
 
@@ -218,10 +217,10 @@ inline void MatrixPartitioned::reaction(
   const xt::xtensor<double,2> &x,
         xt::xtensor<double,2> &b) const
 {
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
 
   Eigen::VectorXd X_u = this->asDofs_u(x);
   Eigen::VectorXd X_p = this->asDofs_p(x);
@@ -241,8 +240,8 @@ inline void MatrixPartitioned::reaction(
   const xt::xtensor<double,1> &x,
         xt::xtensor<double,1> &b) const
 {
-  assert(x.size() == m_ndof);
-  assert(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
 
   Eigen::VectorXd X_u = this->asDofs_u(x);
   Eigen::VectorXd X_p = this->asDofs_p(x);
@@ -261,9 +260,9 @@ inline void MatrixPartitioned::reaction_p(
   const xt::xtensor<double,1> &x_p,
         xt::xtensor<double,1> &b_p) const
 {
-  assert(x_u.shape()[0] == m_nnu);
-  assert(x_p.shape()[0] == m_nnp);
-  assert(b_p.shape()[0] == m_nnp);
+  GOOSEFEM_ASSERT(x_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(x_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(b_p.size() == m_nnp);
 
   Eigen::VectorXd X_u(m_nnu,1);
   Eigen::VectorXd X_p(m_nnp,1);
@@ -283,9 +282,7 @@ inline xt::xtensor<double,2> MatrixPartitioned::Solve(
   const xt::xtensor<double,2> &x)
 {
   xt::xtensor<double,2> out = x;
-
   this->solve(b, out);
-
   return out;
 }
 
@@ -296,9 +293,7 @@ inline xt::xtensor<double,1> MatrixPartitioned::Solve(
   const xt::xtensor<double,1> &x)
 {
   xt::xtensor<double,1> out = x;
-
   this->solve(b, out);
-
   return out;
 }
 
@@ -309,9 +304,7 @@ inline xt::xtensor<double,1> MatrixPartitioned::Solve_u(
   const xt::xtensor<double,1> &x_p)
 {
   xt::xtensor<double,1> x_u = xt::empty<double>({m_nnu});
-
   this->solve_u(b_u, x_p, x_u);
-
   return x_u;
 }
 
@@ -322,9 +315,7 @@ inline xt::xtensor<double,2> MatrixPartitioned::Reaction(
   const xt::xtensor<double,2> &b) const
 {
   xt::xtensor<double,2> out = b;
-
   this->reaction(x, out);
-
   return out;
 }
 
@@ -335,9 +326,7 @@ inline xt::xtensor<double,1> MatrixPartitioned::Reaction(
   const xt::xtensor<double,1> &b) const
 {
   xt::xtensor<double,1> out = b;
-
   this->reaction(x, out);
-
   return out;
 }
 
@@ -348,9 +337,7 @@ inline xt::xtensor<double,1> MatrixPartitioned::Reaction_p(
   const xt::xtensor<double,1> &x_p) const
 {
   xt::xtensor<double,1> b_p = xt::empty<double>({m_nnp});
-
   this->reaction_p(x_u, x_p, b_p);
-
   return b_p;
 }
 
@@ -373,8 +360,8 @@ inline Eigen::VectorXd MatrixPartitioned::asDofs_u(const xt::xtensor<double,1> &
 
 inline Eigen::VectorXd MatrixPartitioned::asDofs_u(const xt::xtensor<double,2> &nodevec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  assert(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   Eigen::VectorXd dofval_u(m_nnu,1);
 
@@ -406,8 +393,8 @@ inline Eigen::VectorXd MatrixPartitioned::asDofs_p(const xt::xtensor<double,1> &
 
 inline Eigen::VectorXd MatrixPartitioned::asDofs_p(const xt::xtensor<double,2> &nodevec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  assert(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   Eigen::VectorXd dofval_p(m_nnp,1);
 

--- a/include/GooseFEM/MatrixPartitionedTyings.hpp
+++ b/include/GooseFEM/MatrixPartitionedTyings.hpp
@@ -27,7 +27,7 @@ inline MatrixPartitionedTyings::MatrixPartitionedTyings(
   m_Cdu(Cdu),
   m_Cdp(Cdp)
 {
-  assert(Cdu.rows() == Cdp.rows());
+  GOOSEFEM_ASSERT(Cdu.rows() == Cdp.rows());
 
   m_nnu   = static_cast<size_t>(m_Cdu.cols());
   m_nnp   = static_cast<size_t>(m_Cdp.cols());
@@ -67,9 +67,9 @@ inline MatrixPartitionedTyings::MatrixPartitionedTyings(
   m_Adp.resize(m_nnd,m_nnp);
   m_Add.resize(m_nnd,m_nnd);
 
-  assert(xt::amax(m_conn)[0] + 1 == m_nnode);
-  assert(m_ndof <= m_nnode * m_ndim);
-  assert(m_ndof == xt::amax(m_dofs)[0] + 1);
+  GOOSEFEM_ASSERT(xt::amax(m_conn)[0] + 1 == m_nnode);
+  GOOSEFEM_ASSERT(m_ndof <= m_nnode * m_ndim);
+  GOOSEFEM_ASSERT(m_ndof == xt::amax(m_dofs)[0] + 1);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -130,9 +130,8 @@ inline void MatrixPartitionedTyings::factorize()
 
 inline void MatrixPartitionedTyings::assemble(const xt::xtensor<double,3> &elemmat)
 {
-  assert(elemmat.shape()[0] == m_nelem     );
-  assert(elemmat.shape()[1] == m_nne*m_ndim);
-  assert(elemmat.shape()[2] == m_nne*m_ndim);
+  GOOSEFEM_ASSERT(elemmat.shape() ==\
+    std::decay_t<decltype(elemmat)>::shape_type({m_nelem, m_nne*m_ndim, m_nne*m_ndim}));
 
   m_Tuu.clear();
   m_Tup.clear();
@@ -198,10 +197,10 @@ inline void MatrixPartitionedTyings::solve(
   const xt::xtensor<double,2> &b,
         xt::xtensor<double,2> &x)
 {
-  assert(b.shape()[0] == m_nnode);
-  assert(b.shape()[1] == m_ndim );
-  assert(x.shape()[0] == m_nnode);
-  assert(x.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(b.shape() ==\
+    std::decay_t<decltype(b)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(x.shape() ==\
+    std::decay_t<decltype(x)>::shape_type({m_nnode, m_ndim}));
 
   this->factorize();
 
@@ -231,8 +230,8 @@ inline void MatrixPartitionedTyings::solve(
   const xt::xtensor<double,1> &b,
         xt::xtensor<double,1> &x)
 {
-  assert(b.size() == m_ndof);
-  assert(x.size() == m_ndof);
+  GOOSEFEM_ASSERT(b.size() == m_ndof);
+  GOOSEFEM_ASSERT(x.size() == m_ndof);
 
   this->factorize();
 
@@ -260,10 +259,10 @@ inline void MatrixPartitionedTyings::solve_u(
   const xt::xtensor<double,1> &x_p,
         xt::xtensor<double,1> &x_u)
 {
-  assert(b_u.shape()[0] == m_nnu);
-  assert(b_d.shape()[0] == m_nnd);
-  assert(x_p.shape()[0] == m_nnp);
-  assert(x_u.shape()[0] == m_nnu);
+  GOOSEFEM_ASSERT(b_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(b_d.size() == m_nnd);
+  GOOSEFEM_ASSERT(x_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(x_u.size() == m_nnu);
 
   this->factorize();
 
@@ -301,8 +300,8 @@ inline Eigen::VectorXd MatrixPartitionedTyings::asDofs_u(
 inline Eigen::VectorXd MatrixPartitionedTyings::asDofs_u(
   const xt::xtensor<double,2> &nodevec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  assert(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   Eigen::VectorXd dofval_u(m_nnu,1);
 
@@ -336,8 +335,8 @@ inline Eigen::VectorXd MatrixPartitionedTyings::asDofs_p(
 inline Eigen::VectorXd MatrixPartitionedTyings::asDofs_p(
   const xt::xtensor<double,2> &nodevec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  assert(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   Eigen::VectorXd dofval_p(m_nnp,1);
 
@@ -371,8 +370,8 @@ inline Eigen::VectorXd MatrixPartitionedTyings::asDofs_d(
 inline Eigen::VectorXd MatrixPartitionedTyings::asDofs_d(
   const xt::xtensor<double,2> &nodevec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  assert(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   Eigen::VectorXd dofval_d(m_nnd,1);
 

--- a/include/GooseFEM/Mesh.hpp
+++ b/include/GooseFEM/Mesh.hpp
@@ -27,8 +27,7 @@ inline Renumber::Renumber(const xt::xarray<size_t>& dofs)
 
   m_renum = xt::empty<size_t>({n});
 
-  for (auto& j : unique)
-  {
+  for (auto& j : unique) {
     m_renum(j) = i;
     ++i;
   }
@@ -74,15 +73,14 @@ inline Reorder::Reorder(const std::initializer_list<xt::xtensor<size_t,1>> args)
   size_t n = 0;
   size_t i = 0;
 
-  for (auto& arg : args)
-  {
+  for (auto& arg : args) {
     if (arg.size() == 0) continue;
     n = std::max(n, xt::amax(arg)[0]+1);
   }
 
-  #ifndef NDEBUG
+  #ifdef GOOSEFEM_ENABLE_ASSERT
     for (auto& arg : args)
-      assert(xt::unique(arg) == xt::sort(arg));
+      GOOSEFEM_ASSERT(xt::unique(arg) == xt::sort(arg));
   #endif
 
   m_renum = xt::empty<size_t>({n});

--- a/include/GooseFEM/MeshHex8.hpp
+++ b/include/GooseFEM/MeshHex8.hpp
@@ -22,9 +22,9 @@ namespace Hex8 {
 inline Regular::Regular(size_t nelx, size_t nely, size_t nelz, double h):
 m_h(h), m_nelx(nelx), m_nely(nely), m_nelz(nelz)
 {
-  assert( m_nelx >= 1 );
-  assert( m_nely >= 1 );
-  assert( m_nelz >= 1 );
+  GOOSEFEM_ASSERT(m_nelx >= 1ul);
+  GOOSEFEM_ASSERT(m_nely >= 1ul);
+  GOOSEFEM_ASSERT(m_nelz >= 1ul);
 
   m_nnode = (m_nelx+1) * (m_nely+1) * (m_nelz+1);
   m_nelem =  m_nelx    *  m_nely    *  m_nelz   ;
@@ -776,9 +776,9 @@ inline FineLayer::FineLayer(size_t nelx, size_t nely, size_t nelz, double h, siz
 m_h(h)
 {
   // basic assumptions
-  assert( nelx >= 1 );
-  assert( nely >= 1 );
-  assert( nelz >= 1 );
+  GOOSEFEM_ASSERT(nelx >= 1ul);
+  GOOSEFEM_ASSERT(nely >= 1ul);
+  GOOSEFEM_ASSERT(nelz >= 1ul);
 
   // store basic info
   m_Lx = m_h * static_cast<double>(nelx);
@@ -991,7 +991,7 @@ inline size_t FineLayer::ndim() const
 
 inline size_t FineLayer::shape(size_t i) const
 {
-  assert( i >= 0 and i <= 2 );
+  GOOSEFEM_ASSERT(i <= 2ul);
 
   if      ( i == 0 ) return xt::amax(m_nelx)[0];
   else if ( i == 2 ) return xt::amax(m_nelz)[0];

--- a/include/GooseFEM/MeshQuad4.hpp
+++ b/include/GooseFEM/MeshQuad4.hpp
@@ -22,8 +22,8 @@ namespace Quad4 {
 inline Regular::Regular(size_t nelx, size_t nely, double h):
 m_h(h), m_nelx(nelx), m_nely(nely)
 {
-  assert( m_nelx >= 1 );
-  assert( m_nely >= 1 );
+  GOOSEFEM_ASSERT(m_nelx >= 1ul);
+  GOOSEFEM_ASSERT(m_nely >= 1ul);
 
   m_nnode = (m_nelx+1) * (m_nely+1);
   m_nelem =  m_nelx    *  m_nely   ;
@@ -302,8 +302,8 @@ inline FineLayer::FineLayer(size_t nelx, size_t nely, double h, size_t nfine):
 m_h(h)
 {
   // basic assumptions
-  assert( nelx >= 1 );
-  assert( nely >= 1 );
+  GOOSEFEM_ASSERT(nelx >= 1ul);
+  GOOSEFEM_ASSERT(nely >= 1ul);
 
   // store basic info
   m_Lx = m_h * static_cast<double>(nelx);
@@ -455,7 +455,7 @@ inline size_t FineLayer::ndim() const
 
 inline size_t FineLayer::shape(size_t i) const
 {
-  assert( i >= 0 and i <= 1 );
+  GOOSEFEM_ASSERT(i <= 1ul);
 
   if ( i == 0 ) return xt::amax(m_nelx)[0];
   else          return xt::sum (m_nhy )[0];

--- a/include/GooseFEM/MeshTri3.hpp
+++ b/include/GooseFEM/MeshTri3.hpp
@@ -22,8 +22,8 @@ namespace Tri3 {
 inline Regular::Regular(size_t nelx, size_t nely, double h):
 m_h(h), m_nelx(nelx), m_nely(nely)
 {
-  assert( m_nelx >= 1 );
-  assert( m_nely >= 1 );
+  GOOSEFEM_ASSERT(m_nelx >= 1ul);
+  GOOSEFEM_ASSERT(m_nely >= 1ul);
 
   m_nnode = (m_nelx+1) * (m_nely+1);
   m_nelem =  m_nelx    *  m_nely * 2;
@@ -296,8 +296,8 @@ inline xt::xtensor<size_t,2> Regular::dofsPeriodic() const
 
 inline xt::xtensor<int,1> getOrientation(const xt::xtensor<double,2> &coor, const xt::xtensor<size_t,2> &conn)
 {
-  assert( conn.shape()[1] == 3 );
-  assert( coor.shape()[1] == 2 );
+  GOOSEFEM_ASSERT(conn.shape()[1] == 3ul);
+  GOOSEFEM_ASSERT(coor.shape()[1] == 2ul);
 
   double k;
   size_t nelem = conn.shape()[0];
@@ -322,9 +322,9 @@ inline xt::xtensor<int,1> getOrientation(const xt::xtensor<double,2> &coor, cons
 
 inline xt::xtensor<size_t,2> setOrientation(const xt::xtensor<double,2> &coor, const xt::xtensor<size_t,2> &conn, int orientation)
 {
-  assert( conn.shape()[1] == 3 );
-  assert( coor.shape()[1] == 2 );
-  assert( orientation == -1 || orientation == +1 );
+  GOOSEFEM_ASSERT(conn.shape()[1] == 3ul);
+  GOOSEFEM_ASSERT(coor.shape()[1] == 2ul);
+  GOOSEFEM_ASSERT(orientation == -1 || orientation == +1);
 
   xt::xtensor<int,1> val = getOrientation(coor, conn);
 
@@ -335,10 +335,10 @@ inline xt::xtensor<size_t,2> setOrientation(const xt::xtensor<double,2> &coor, c
 
 inline xt::xtensor<size_t,2> setOrientation(const xt::xtensor<double,2> &coor, const xt::xtensor<size_t,2> &conn, const xt::xtensor<int,1> &val, int orientation)
 {
-  assert( conn.shape()[1] == 3 );
-  assert( coor.shape()[1] == 2 );
-  assert( conn.shape()[0] == val.size() );
-  assert( orientation == -1 || orientation == +1 );
+  GOOSEFEM_ASSERT(conn.shape()[1] == 3ul);
+  GOOSEFEM_ASSERT(coor.shape()[1] == 2ul);
+  GOOSEFEM_ASSERT(conn.shape()[0] == val.size());
+  GOOSEFEM_ASSERT(orientation == -1 || orientation == +1);
 
   // avoid compiler warning
   UNUSED(coor);
@@ -390,8 +390,8 @@ namespace Private {
 
 inline TriUpdate::TriUpdate(const xt::xtensor<double,2> &coor, const xt::xtensor<size_t,2> &conn): m_conn(conn), m_coor(coor)
 {
-  assert( conn.shape()[1] == 3 );
-  assert( coor.shape()[1] == 2 );
+  GOOSEFEM_ASSERT(conn.shape()[1] == 3ul);
+  GOOSEFEM_ASSERT(coor.shape()[1] == 2ul);
 
   // store shapes
   m_nnode = coor.shape()[0];

--- a/include/GooseFEM/Vector.hpp
+++ b/include/GooseFEM/Vector.hpp
@@ -32,8 +32,8 @@ inline Vector::Vector(
   m_ndof  = xt::amax(m_dofs)[0] + 1;
 
   // check consistency
-  assert(xt::amax(m_conn)[0] + 1 == m_nnode);
-  assert(m_ndof <= m_nnode * m_ndim);
+  GOOSEFEM_ASSERT(xt::amax(m_conn)[0] + 1 == m_nnode);
+  GOOSEFEM_ASSERT(m_ndof <= m_nnode * m_ndim);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -62,10 +62,10 @@ inline void Vector::copy(
   const xt::xtensor<double,2>& nodevec_src,
         xt::xtensor<double,2>& nodevec_dest) const
 {
-  assert(nodevec_src .shape()[0] == m_nnode);
-  assert(nodevec_src .shape()[1] == m_ndim );
-  assert(nodevec_dest.shape()[0] == m_nnode);
-  assert(nodevec_dest.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec_src.shape() ==\
+    std::decay_t<decltype(nodevec_src)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec_dest.shape() ==\
+    std::decay_t<decltype(nodevec_dest)>::shape_type({m_nnode, m_ndim}));
 
   xt::noalias(nodevec_dest) = nodevec_src;
 }
@@ -76,9 +76,9 @@ inline void Vector::asDofs(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -92,10 +92,9 @@ inline void Vector::asDofs(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -110,9 +109,9 @@ inline void Vector::asNode(
   const xt::xtensor<double,1>& dofval,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(dofval.size()      == m_ndof );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -126,11 +125,10 @@ inline void Vector::asNode(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -145,10 +143,9 @@ inline void Vector::asElement(
   const xt::xtensor<double,1>& dofval,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(dofval.size()      == m_ndof );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -163,11 +160,10 @@ inline void Vector::asElement(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -182,9 +178,9 @@ inline void Vector::assembleDofs(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   dofval.fill(0.0);
 
@@ -199,10 +195,9 @@ inline void Vector::assembleDofs(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   dofval.fill(0.0);
 
@@ -218,11 +213,10 @@ inline void Vector::assembleNode(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   // assemble to DOFs
   xt::xtensor<double,1> dofval = this->AssembleDofs(elemvec);

--- a/include/GooseFEM/VectorPartitioned.hpp
+++ b/include/GooseFEM/VectorPartitioned.hpp
@@ -39,9 +39,9 @@ inline VectorPartitioned::VectorPartitioned(
 
   m_part  = Mesh::Reorder({m_iiu, m_iip}).get(m_dofs);
 
-  assert(xt::amax(m_conn)[0] + 1 == m_nnode);
-  assert(xt::amax(m_iip)[0] <= xt::amax(m_dofs)[0]);
-  assert(m_ndof <= m_nnode * m_ndim);
+  GOOSEFEM_ASSERT(xt::amax(m_conn)[0] + 1 == m_nnode);
+  GOOSEFEM_ASSERT(xt::amax(m_iip)[0] <= xt::amax(m_dofs)[0]);
+  GOOSEFEM_ASSERT(m_ndof <= m_nnode * m_ndim);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -82,10 +82,10 @@ inline void VectorPartitioned::copy(
   const xt::xtensor<double,2>& nodevec_src,
         xt::xtensor<double,2>& nodevec_dest) const
 {
-  assert(nodevec_src .shape()[0] == m_nnode);
-  assert(nodevec_src .shape()[1] == m_ndim );
-  assert(nodevec_dest.shape()[0] == m_nnode);
-  assert(nodevec_dest.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec_src.shape() ==\
+    std::decay_t<decltype(nodevec_src)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec_dest.shape() ==\
+    std::decay_t<decltype(nodevec_dest)>::shape_type({m_nnode, m_ndim}));
 
   xt::noalias(nodevec_dest) = nodevec_src;
 }
@@ -96,10 +96,10 @@ inline void VectorPartitioned::copy_u(
   const xt::xtensor<double,2>& nodevec_src,
         xt::xtensor<double,2>& nodevec_dest) const
 {
-  assert(nodevec_src .shape()[0] == m_nnode);
-  assert(nodevec_src .shape()[1] == m_ndim );
-  assert(nodevec_dest.shape()[0] == m_nnode);
-  assert(nodevec_dest.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec_src.shape() ==\
+    std::decay_t<decltype(nodevec_src)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec_dest.shape() ==\
+    std::decay_t<decltype(nodevec_dest)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -114,10 +114,10 @@ inline void VectorPartitioned::copy_p(
   const xt::xtensor<double,2>& nodevec_src,
         xt::xtensor<double,2>& nodevec_dest) const
 {
-  assert(nodevec_src .shape()[0] == m_nnode);
-  assert(nodevec_src .shape()[1] == m_ndim );
-  assert(nodevec_dest.shape()[0] == m_nnode);
-  assert(nodevec_dest.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec_src.shape() ==\
+    std::decay_t<decltype(nodevec_src)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec_dest.shape() ==\
+    std::decay_t<decltype(nodevec_dest)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -133,9 +133,9 @@ inline void VectorPartitioned::asDofs(
   const xt::xtensor<double,1>& dofval_p,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(dofval_u.size() == m_nnu );
-  assert(dofval_p.size() == m_nnp );
-  assert(dofval.size()   == m_ndof);
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnu ; ++d)
@@ -152,9 +152,9 @@ inline void VectorPartitioned::asDofs(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -168,8 +168,8 @@ inline void VectorPartitioned::asDofs_u(
   const xt::xtensor<double,1>& dofval,
         xt::xtensor<double,1>& dofval_u) const
 {
-  assert(dofval.size()   == m_ndof);
-  assert(dofval_u.size() == m_nnu );
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnu ; ++d)
@@ -182,9 +182,9 @@ inline void VectorPartitioned::asDofs_u(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval_u) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval_u.size()    == m_nnu  );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -199,8 +199,8 @@ inline void VectorPartitioned::asDofs_p(
   const xt::xtensor<double,1>& dofval,
         xt::xtensor<double,1>& dofval_p) const
 {
-  assert(dofval.size()   == m_ndof);
-  assert(dofval_p.size() == m_nnp );
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
 
   #pragma omp parallel for
   for (size_t d = 0 ; d < m_nnp ; ++d)
@@ -213,9 +213,9 @@ inline void VectorPartitioned::asDofs_p(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval_p) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval_p.size()    == m_nnp  );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -230,10 +230,9 @@ inline void VectorPartitioned::asDofs(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -248,10 +247,9 @@ inline void VectorPartitioned::asDofs_u(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval_u) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval_u.size()    == m_nnu  );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -267,10 +265,9 @@ inline void VectorPartitioned::asDofs_p(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval_p) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval_p.size()    == m_nnp  );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -286,9 +283,9 @@ inline void VectorPartitioned::asNode(
   const xt::xtensor<double,1>& dofval,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(dofval.size()      == m_ndof );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -303,10 +300,10 @@ inline void VectorPartitioned::asNode(
   const xt::xtensor<double,1>& dofval_p,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(dofval_u.size()    == m_nnu  );
-  assert(dofval_p.size()    == m_nnp  );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m) {
@@ -325,11 +322,10 @@ inline void VectorPartitioned::asNode(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -344,10 +340,9 @@ inline void VectorPartitioned::asElement(
   const xt::xtensor<double,1>& dofval,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(dofval.size()      == m_ndof );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -363,11 +358,10 @@ inline void VectorPartitioned::asElement(
   const xt::xtensor<double,1>& dofval_p,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(dofval_u.size()    == m_nnu  );
-  assert(dofval_p.size()    == m_nnp  );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e) {
@@ -388,11 +382,10 @@ inline void VectorPartitioned::asElement(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -407,9 +400,9 @@ inline void VectorPartitioned::assembleDofs(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   dofval.fill(0.0);
 
@@ -424,9 +417,9 @@ inline void VectorPartitioned::assembleDofs_u(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval_u) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval_u.size()    == m_nnu  );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
 
   dofval_u.fill(0.0);
 
@@ -442,9 +435,9 @@ inline void VectorPartitioned::assembleDofs_p(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,1>& dofval_p) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval_p.size()    == m_nnp  );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
 
   dofval_p.fill(0.0);
 
@@ -460,10 +453,9 @@ inline void VectorPartitioned::assembleDofs(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   dofval.fill(0.0);
 
@@ -479,10 +471,9 @@ inline void VectorPartitioned::assembleDofs_u(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval_u) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval_u.size()    == m_nnu  );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_u.size() == m_nnu);
 
   dofval_u.fill(0.0);
 
@@ -499,10 +490,9 @@ inline void VectorPartitioned::assembleDofs_p(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval_p) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval_p.size()    == m_nnp  );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_p.size() == m_nnp);
 
   dofval_p.fill(0.0);
 
@@ -519,11 +509,10 @@ inline void VectorPartitioned::assembleNode(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   xt::xtensor<double,1> dofval = this->AssembleDofs(elemvec);
 

--- a/include/GooseFEM/VectorPartitionedTyings.hpp
+++ b/include/GooseFEM/VectorPartitionedTyings.hpp
@@ -29,8 +29,8 @@ inline VectorPartitionedTyings::VectorPartitionedTyings(
   m_Cdp(Cdp),
   m_Cdi(Cdi)
 {
-  assert(Cdu.rows() == Cdp.rows());
-  assert(Cdi.rows() == Cdp.rows());
+  GOOSEFEM_ASSERT(Cdu.rows() == Cdp.rows());
+  GOOSEFEM_ASSERT(Cdi.rows() == Cdp.rows());
 
   m_nnu   = static_cast<size_t>(m_Cdu.cols());
   m_nnp   = static_cast<size_t>(m_Cdp.cols());
@@ -51,10 +51,10 @@ inline VectorPartitionedTyings::VectorPartitionedTyings(
   m_Cpd   = m_Cdp.transpose();
   m_Cid   = m_Cdi.transpose();
 
-  assert(static_cast<size_t>(m_Cdi.cols()) == m_nni);
-  assert(xt::amax(m_conn)[0] + 1 == m_nnode);
-  assert(m_ndof <= m_nnode * m_ndim);
-  assert(m_ndof == xt::amax(m_dofs)[0] + 1);
+  GOOSEFEM_ASSERT(static_cast<size_t>(m_Cdi.cols()) == m_nni);
+  GOOSEFEM_ASSERT(xt::amax(m_conn)[0] + 1 == m_nnode);
+  GOOSEFEM_ASSERT(m_ndof <= m_nnode * m_ndim);
+  GOOSEFEM_ASSERT(m_ndof == xt::amax(m_dofs)[0] + 1);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -107,8 +107,8 @@ inline void VectorPartitionedTyings::copy_p(
   const xt::xtensor<double,1>& dofval_src,
         xt::xtensor<double,1>& dofval_dest) const
 {
-  assert(dofval_src.size() == m_ndof || dofval_src.size() == m_nni);
-  assert(dofval_dest.size() == m_ndof || dofval_dest.size() == m_nni);
+  GOOSEFEM_ASSERT(dofval_src.size() == m_ndof || dofval_src.size() == m_nni);
+  GOOSEFEM_ASSERT(dofval_dest.size() == m_ndof || dofval_dest.size() == m_nni);
 
   #pragma omp parallel for
   for (size_t i = m_nnu; i < m_nni; ++i)
@@ -122,9 +122,9 @@ inline void VectorPartitionedTyings::asDofs_i(
         xt::xtensor<double,1>& dofval_i,
         bool apply_tyings) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(dofval_i.size()    == m_nni  );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(dofval_i.size() == m_nni);
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -149,9 +149,9 @@ inline void VectorPartitionedTyings::asNode(
   const xt::xtensor<double,1>& dofval,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(dofval.size()      == m_ndof );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   #pragma omp parallel for
   for (size_t m = 0 ; m < m_nnode ; ++m)
@@ -165,11 +165,10 @@ inline void VectorPartitionedTyings::asElement(
   const xt::xtensor<double,2>& nodevec,
         xt::xtensor<double,3>& elemvec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
 
   #pragma omp parallel for
   for (size_t e = 0 ; e < m_nelem ; ++e)
@@ -184,10 +183,9 @@ inline void VectorPartitionedTyings::assembleDofs(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,1>& dofval) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(dofval.size()      == m_ndof );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(dofval.size() == m_ndof);
 
   dofval.fill(0.0);
 
@@ -203,11 +201,10 @@ inline void VectorPartitionedTyings::assembleNode(
   const xt::xtensor<double,3>& elemvec,
         xt::xtensor<double,2>& nodevec) const
 {
-  assert(elemvec.shape()[0] == m_nelem);
-  assert(elemvec.shape()[1] == m_nne  );
-  assert(elemvec.shape()[2] == m_ndim );
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(elemvec.shape() ==\
+    std::decay_t<decltype(elemvec)>::shape_type({m_nelem, m_nne, m_ndim}));
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   xt::xtensor<double,1> dofval = this->AssembleDofs(elemvec);
 
@@ -255,8 +252,8 @@ inline xt::xtensor<double,2> VectorPartitionedTyings::AssembleNode(
 inline Eigen::VectorXd VectorPartitionedTyings::Eigen_asDofs_d(
   const xt::xtensor<double,2>& nodevec) const
 {
-  assert(nodevec.shape()[0] == m_nnode);
-  assert(nodevec.shape()[1] == m_ndim );
+  GOOSEFEM_ASSERT(nodevec.shape() ==\
+    std::decay_t<decltype(nodevec)>::shape_type({m_nnode, m_ndim}));
 
   Eigen::VectorXd dofval_d(m_nnd,1);
 

--- a/include/GooseFEM/config.h
+++ b/include/GooseFEM/config.h
@@ -7,7 +7,7 @@
 #ifndef GOOSEFEM_CONFIG_H
 #define GOOSEFEM_CONFIG_H
 
-// =================================================================================================
+// -------------------------------------------------------------------------------------------------
 
 #define _USE_MATH_DEFINES // to use "M_PI" from "math.h"
 
@@ -39,11 +39,33 @@
 
 using namespace xt::placeholders;
 
-// =================================================================================================
+// -------------------------------------------------------------------------------------------------
+
+// dummy operation that can be use to suppress the "unused parameter" warnings
+#define UNUSED(p) ( (void)(p) )
+
+// -------------------------------------------------------------------------------------------------
+
+#ifndef NDEBUG
+#define GOOSEFEM_ENABLE_ASSERT
+#endif
+
+#ifdef GOOSEFEM_ENABLE_ASSERT
+#define GOOSEFEM_ASSERT(expr) GOOSEFEM_ASSERT_IMPL(expr, __FILE__, __LINE__)
+#define GOOSEFEM_ASSERT_IMPL(expr, file, line)                                                                            \
+    if (!(expr))                                                                                                          \
+    {                                                                                                                     \
+        throw std::runtime_error(std::string(file) + ':' + std::to_string(line) + ": assertion failed (" #expr ") \n\t"); \
+    }
+#else
+#define GOOSEFEM_ASSERT(expr)
+#endif
+
+// -------------------------------------------------------------------------------------------------
 
 #define GOOSEFEM_WORLD_VERSION 0
 #define GOOSEFEM_MAJOR_VERSION 2
-#define GOOSEFEM_MINOR_VERSION 0
+#define GOOSEFEM_MINOR_VERSION 1
 
 #define GOOSEFEM_VERSION_AT_LEAST(x,y,z) \
   (GOOSEFEM_WORLD_VERSION>x || (GOOSEFEM_WORLD_VERSION>=x && \
@@ -55,11 +77,6 @@ using namespace xt::placeholders;
    GOOSEFEM_MAJOR_VERSION==y && \
    GOOSEFEM_MINOR_VERSION==z)
 
-// =================================================================================================
-
-// dummy operation that can be use to suppress the "unused parameter" warnings
-#define UNUSED(p) ( (void)(p) )
-
-// =================================================================================================
+// -------------------------------------------------------------------------------------------------
 
 #endif

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -11,6 +11,7 @@
 
 #include <pyxtensor/pyxtensor.hpp>
 
+#define GOOSEFEM_ENABLE_ASSERT
 #include "../include/GooseFEM/GooseFEM.h"
 
 // =================================================================================================

--- a/test/Iterate.cpp
+++ b/test/Iterate.cpp
@@ -8,7 +8,7 @@ TEST_CASE("GooseFEM::Iterate", "Iterate.h")
 
 // =================================================================================================
 
-SECTION( "StopList" )
+SECTION("StopList")
 {
   GooseFEM::Iterate::StopList stop(5);
 

--- a/test/MatrixDiagonal.cpp
+++ b/test/MatrixDiagonal.cpp
@@ -8,7 +8,7 @@ TEST_CASE("GooseFEM::MatrixDiagonal", "MatrixDiagonal.h")
 
 // =================================================================================================
 
-SECTION( "dot" )
+SECTION("dot")
 {
   // mesh
   GooseFEM::Mesh::Quad4::Regular mesh(2,2);
@@ -40,7 +40,7 @@ SECTION( "dot" )
 
 // -------------------------------------------------------------------------------------------------
 
-SECTION( "solve" )
+SECTION("solve")
 {
   // mesh
   GooseFEM::Mesh::Quad4::Regular mesh(2,2);

--- a/test/Vector.cpp
+++ b/test/Vector.cpp
@@ -8,7 +8,7 @@ TEST_CASE("GooseFEM::Vector", "Vector.h")
 
 // =================================================================================================
 
-SECTION( "asDofs - nodevec" )
+SECTION("asDofs - nodevec")
 {
   // mesh
   GooseFEM::Mesh::Quad4::Regular mesh(2,2);
@@ -49,7 +49,7 @@ SECTION( "asDofs - nodevec" )
 
 // -------------------------------------------------------------------------------------------------
 
-SECTION( "asDofs - elemvec" )
+SECTION("asDofs - elemvec")
 {
   // mesh
   GooseFEM::Mesh::Quad4::Regular mesh(2,2);
@@ -90,7 +90,7 @@ SECTION( "asDofs - elemvec" )
 
 // -------------------------------------------------------------------------------------------------
 
-SECTION( "asDofs - assembleDofs" )
+SECTION("asDofs - assembleDofs")
 {
   // mesh
   GooseFEM::Mesh::Quad4::Regular mesh(2,2);
@@ -131,7 +131,7 @@ SECTION( "asDofs - assembleDofs" )
 
 // -------------------------------------------------------------------------------------------------
 
-SECTION( "asDofs - assembleNode" )
+SECTION("asDofs - assembleNode")
 {
   // mesh
   GooseFEM::Mesh::Quad4::Regular mesh(2,2);

--- a/test/VectorPartitioned.cpp
+++ b/test/VectorPartitioned.cpp
@@ -8,7 +8,7 @@ TEST_CASE("GooseFEM::VectorPartitioned", "VectorPartitioned.h")
 
 // =================================================================================================
 
-SECTION( "asDofs" )
+SECTION("asDofs")
 {
   // mesh
 
@@ -58,7 +58,7 @@ SECTION( "asDofs" )
 
 // =================================================================================================
 
-SECTION( "copy_u, copy_p" )
+SECTION("copy_u, copy_p")
 {
   // mesh
 

--- a/test/support.h
+++ b/test/support.h
@@ -8,8 +8,10 @@
 #include <xtensor/xmath.hpp>
 
 #include <Eigen/Eigen>
+
+#define GOOSEFEM_ENABLE_ASSERT
 #include "../include/GooseFEM/GooseFEM.h"
 
-#define EQ(a,b) REQUIRE_THAT( (a), Catch::WithinAbs((b), 1.e-12) );
+#define EQ(a,b) REQUIRE_THAT((a), Catch::WithinAbs((b), 1.e-12));
 
 #endif


### PR DESCRIPTION
Allows retaining some assertions also when `NDEBUG` is specified (e.g. for Python module), by using

```cpp
#define GOOSEFEM_ENABLE_ASSERT
```

Closes #23